### PR TITLE
Update WorkspaceONE_ReEnrollment.ps1

### DIFF
--- a/Scripts/WorkspaceONE_ReEnrollment.ps1
+++ b/Scripts/WorkspaceONE_ReEnrollment.ps1
@@ -49,7 +49,7 @@ if ($KeepAppsInstalled -eq "true") {
 }
 
 #Uninstall Agent - requires manual delete of device object in console
-$HUB = Get-WmiObject -Class win32_product -Filter "Name like '%Workspace ONE%'"
+$HUB = Get-WmiObject -Class win32_product -Filter "Name like '%Workspace ONE Intelligent%'"
 $Arguments = "/x $($HUB.IdentifyingNumber) /q /norestart"
 Start-Process msiexec -ArgumentList $Arguments -Wait 
 


### PR DESCRIPTION
If the Tunnel is installed, this command will take both Hub & Tunnel ID and then generate an error with msiexec. If we specified this change, only the hub identifier will be retrieved